### PR TITLE
Add granular work stages for better status visibility

### DIFF
--- a/genai/work
+++ b/genai/work
@@ -41,7 +41,7 @@ Worker Management:
   $(basename "$0") --send <issue> <message>    # Send message to worker
   $(basename "$0") --messages [issue]          # View and mark messages as read
   $(basename "$0") --messages [issue] --peek   # View without marking as read
-  $(basename "$0") --stage <stage> [--pr N]    # Set current work stage (from worker)
+  $(basename "$0") --stage <stage> [issue]     # Set worker stage (for progress tracking)
 
 Options:
   --here       Run in current terminal instead of spawning new tab
@@ -51,12 +51,9 @@ Options:
   --stop       Terminate a specific worker
   --send       Send a message to a worker (use --type <type> for custom types)
   --messages   View pending messages (marks as read by default; use --peek to keep unread)
-  --stage      Set current work stage (must be run from worker session)
+  --stage      Set worker stage (exploring, planning, implementing, testing, pr_creating,
+               ci_waiting, review_waiting, review_responding, merge_conflicts, done, blocked)
   --help       Show this help message
-
-Stages:
-  exploring, planning, implementing, testing, pr_creating,
-  ci_waiting, review_waiting, review_responding, merge_conflicts, done, blocked
 
 Environment:
   MAIN_BRANCH    Base branch for new branches (default: main)
@@ -85,7 +82,6 @@ CREATE TABLE IF NOT EXISTS workers (
     status TEXT DEFAULT 'starting',
     phase TEXT DEFAULT 'implementation',
     stage TEXT DEFAULT 'exploring',
-    stage_changed_at TEXT DEFAULT CURRENT_TIMESTAMP,
     pr_number INTEGER,
     pr_url TEXT,
     started_at TEXT DEFAULT CURRENT_TIMESTAMP,
@@ -131,15 +127,11 @@ CREATE INDEX IF NOT EXISTS idx_messages_worker ON messages(worker_id);
 CREATE INDEX IF NOT EXISTS idx_messages_unread ON messages(worker_id, read_at);
 SQL
 
-    # Migrate existing databases: add stage and stage_changed_at columns if missing
-    # Note: SQLite doesn't allow CURRENT_TIMESTAMP as default in ALTER TABLE, so we use NULL
-    # and update existing rows separately
-    if ! sqlite3 "$DB_PATH" "SELECT stage FROM workers LIMIT 1;" &>/dev/null; then
-        sqlite3 "$DB_PATH" "ALTER TABLE workers ADD COLUMN stage TEXT DEFAULT 'exploring';" 2>/dev/null || true
-    fi
-    if ! sqlite3 "$DB_PATH" "SELECT stage_changed_at FROM workers LIMIT 1;" &>/dev/null; then
-        sqlite3 "$DB_PATH" "ALTER TABLE workers ADD COLUMN stage_changed_at TEXT;" 2>/dev/null || true
-        sqlite3 "$DB_PATH" "UPDATE workers SET stage_changed_at = COALESCE(updated_at, CURRENT_TIMESTAMP) WHERE stage_changed_at IS NULL;" 2>/dev/null || true
+    # Migration: add stage column if it doesn't exist (for existing databases)
+    local has_stage
+    has_stage=$(sqlite3 "$DB_PATH" "SELECT COUNT(*) FROM pragma_table_info('workers') WHERE name='stage';")
+    if [[ "$has_stage" -eq 0 ]]; then
+        sqlite3 "$DB_PATH" "ALTER TABLE workers ADD COLUMN stage TEXT DEFAULT 'exploring';"
     fi
 }
 
@@ -157,8 +149,8 @@ db_register_worker() {
 
     # Use INSERT OR REPLACE to handle re-runs on the same branch
     sqlite3 "$DB_PATH" <<SQL
-INSERT OR REPLACE INTO workers (repo_path, repo_name, issue_number, branch, worktree_path, pid, status, phase, stage, stage_changed_at, started_at, updated_at)
-VALUES ('$repo_path', '$repo_name', ${issue_number:-NULL}, '$branch', '$worktree_path', $pid, 'starting', 'implementation', 'exploring', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+INSERT OR REPLACE INTO workers (repo_path, repo_name, issue_number, branch, worktree_path, pid, status, phase, stage, started_at, updated_at)
+VALUES ('$repo_path', '$repo_name', ${issue_number:-NULL}, '$branch', '$worktree_path', $pid, 'starting', 'implementation', 'exploring', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
 SQL
 
     # Return the worker ID
@@ -178,27 +170,22 @@ db_update_status() {
     fi
 }
 
-# Valid stages for workers
-VALID_STAGES="exploring planning implementing testing pr_creating ci_waiting review_waiting review_responding merge_conflicts done blocked"
-
-# Validate a stage name
-is_valid_stage() {
-    local stage="$1"
-    [[ " $VALID_STAGES " == *" $stage "* ]]
-}
-
-# Update worker stage
+# Update worker stage (granular progress tracking)
+# Valid stages: exploring, planning, implementing, testing, pr_creating,
+#               ci_waiting, review_waiting, review_responding, merge_conflicts, done, blocked
 db_update_stage() {
     local worker_id="$1"
     local stage="$2"
 
-    if ! is_valid_stage "$stage"; then
+    # Validate stage
+    local valid_stages="exploring planning implementing testing pr_creating ci_waiting review_waiting review_responding merge_conflicts done blocked"
+    if ! echo "$valid_stages" | grep -qw "$stage"; then
         echo "Error: Invalid stage '$stage'"
-        echo "Valid stages: $VALID_STAGES"
+        echo "Valid stages: $valid_stages"
         return 1
     fi
 
-    sqlite3 "$DB_PATH" "UPDATE workers SET stage='$stage', stage_changed_at=CURRENT_TIMESTAMP, updated_at=CURRENT_TIMESTAMP WHERE id=$worker_id;"
+    sqlite3 "$DB_PATH" "UPDATE workers SET stage='$stage', updated_at=CURRENT_TIMESTAMP WHERE id=$worker_id;"
     db_log_event "$worker_id" "stage_change" "Stage changed to: $stage"
 }
 
@@ -333,34 +320,23 @@ cmd_status() {
     db_cleanup_stale_workers
 
     echo "Active Workers:"
-    echo "-----------------------------------------------------------------------------------------------------------"
-    printf "%-20s | %-6s | %-17s | %-8s | %-6s | %s\n" "repo_name" "issue" "stage" "in_stage" "pr" "status"
-    echo "-----------------------------------------------------------------------------------------------------------"
+    echo "-------------------------------------------------------------------------------"
+    printf "%-20s | %-6s | %-10s | %-17s | %s\n" "repo_name" "issue" "status" "stage" "mins_idle"
+    echo "-------------------------------------------------------------------------------"
 
     sqlite3 -separator '|' "$DB_PATH" "
-        SELECT repo_name, COALESCE(issue_number, '-'), stage,
-               CAST((julianday('now') - julianday(stage_changed_at)) * 24 * 60 AS INTEGER),
-               COALESCE(CAST(pr_number AS TEXT), '-'),
-               status
+        SELECT repo_name, COALESCE(issue_number, '-'), status, COALESCE(stage, phase),
+               CAST((julianday('now') - julianday(updated_at)) * 24 * 60 AS INTEGER)
         FROM workers
         WHERE status NOT IN ('done', 'failed')
         ORDER BY updated_at DESC;
-    " | while IFS='|' read -r repo_name issue stage mins_in_stage pr_num status; do
-        # Format time in stage (e.g., "5m", "2h", "1d")
-        local time_str
-        if [[ "$mins_in_stage" -lt 60 ]]; then
-            time_str="${mins_in_stage}m"
-        elif [[ "$mins_in_stage" -lt 1440 ]]; then
-            time_str="$((mins_in_stage / 60))h"
-        else
-            time_str="$((mins_in_stage / 1440))d"
-        fi
-        printf "%-20s | %-6s | %-17s | %-8s | %-6s | %s\n" "$repo_name" "$issue" "$stage" "$time_str" "$pr_num" "$status"
+    " | while IFS='|' read -r repo_name issue status stage mins_idle; do
+        printf "%-20s | %-6s | %-10s | %-17s | %s\n" "$repo_name" "$issue" "$status" "$stage" "$mins_idle"
     done
 
     local count
     count=$(sqlite3 "$DB_PATH" "SELECT COUNT(*) FROM workers WHERE status NOT IN ('done', 'failed');")
-    echo "-----------------------------------------------------------------------------------------------------------"
+    echo "-------------------------------------------------------------------------------"
     echo "Total active workers: $count"
 }
 
@@ -525,81 +501,6 @@ cmd_send() {
     echo "  Message: $message"
 }
 
-# Set stage for a worker
-cmd_stage() {
-    local stage="${1:-}"
-
-    if [[ -z "$stage" ]]; then
-        echo "Error: --stage requires a stage name"
-        echo "Usage: work --stage <stage> [--pr <number>]"
-        echo ""
-        echo "Valid stages:"
-        echo "  exploring        - Reading issue, understanding codebase"
-        echo "  planning         - Designing approach, creating todo list"
-        echo "  implementing     - Writing code"
-        echo "  testing          - Running local tests"
-        echo "  pr_creating      - Creating PR, writing description"
-        echo "  ci_waiting       - PR created, waiting for CI to pass"
-        echo "  review_waiting   - CI passed, waiting for review"
-        echo "  review_responding - Addressing review feedback"
-        echo "  merge_conflicts  - Resolving merge conflicts"
-        echo "  done             - PR merged or issue closed"
-        echo "  blocked          - Waiting on external dependency"
-        exit 1
-    fi
-
-    shift
-
-    # Parse optional --pr flag
-    local pr_number=""
-    while [[ $# -gt 0 ]]; do
-        case "$1" in
-            --pr)
-                pr_number="$2"
-                shift 2
-                ;;
-            *)
-                echo "Unknown option: $1"
-                exit 1
-                ;;
-        esac
-    done
-
-    init_db
-
-    # Get worker ID from environment or fail
-    local worker_id="${WORK_WORKER_ID:-}"
-    if [[ -z "$worker_id" ]]; then
-        echo "Error: --stage must be run from within a worker session (WORK_WORKER_ID not set)"
-        exit 1
-    fi
-
-    if ! is_valid_stage "$stage"; then
-        echo "Error: Invalid stage '$stage'"
-        echo "Valid stages: $VALID_STAGES"
-        exit 1
-    fi
-
-    db_update_stage "$worker_id" "$stage"
-
-    # If PR number provided, update that too
-    if [[ -n "$pr_number" ]]; then
-        local pr_url
-        local remote_url
-        remote_url=$(git remote get-url origin 2>/dev/null || echo "")
-        if [[ "$remote_url" =~ github\.com[:/]([^/]+)/([^/.]+) ]]; then
-            local owner="${BASH_REMATCH[1]}"
-            local repo="${BASH_REMATCH[2]}"
-            pr_url="https://github.com/${owner}/${repo}/pull/${pr_number}"
-        else
-            pr_url=""
-        fi
-        sqlite3 "$DB_PATH" "UPDATE workers SET pr_number=$pr_number, pr_url='$pr_url', updated_at=CURRENT_TIMESTAMP WHERE id=$worker_id;"
-    fi
-
-    echo "Stage updated to: $stage"
-}
-
 # View messages for a worker (from worker's perspective)
 # Messages are marked as read by default; use --peek to view without marking
 cmd_messages() {
@@ -650,6 +551,53 @@ cmd_messages() {
         echo "All messages marked as read."
     else
         echo "(Peek mode - messages NOT marked as read)"
+    fi
+}
+
+# Set stage for a worker (worker self-reports its current stage)
+cmd_stage() {
+    local stage="${1:-}"
+    local issue_number="${2:-}"
+
+    if [[ -z "$stage" ]]; then
+        echo "Error: --stage requires a stage name"
+        echo "Usage: work --stage <stage> [issue]"
+        echo ""
+        echo "Valid stages:"
+        echo "  exploring        - Reading issue, understanding codebase"
+        echo "  planning         - Designing approach, creating todo list"
+        echo "  implementing     - Writing code"
+        echo "  testing          - Running local tests"
+        echo "  pr_creating      - Creating PR, writing description"
+        echo "  ci_waiting       - PR created, waiting for CI to pass"
+        echo "  review_waiting   - CI passed, waiting for review"
+        echo "  review_responding - Addressing review feedback"
+        echo "  merge_conflicts  - Resolving merge conflicts"
+        echo "  done             - PR merged or issue closed"
+        echo "  blocked          - Waiting on external dependency"
+        exit 1
+    fi
+
+    init_db
+
+    # Find the worker ID
+    local worker_id=""
+    if [[ -n "$issue_number" ]]; then
+        worker_id=$(db_get_worker_by_issue "$issue_number")
+        if [[ -z "$worker_id" ]]; then
+            echo "Error: No active worker found for issue #$issue_number"
+            exit 1
+        fi
+    elif [[ -n "${WORK_WORKER_ID:-}" ]]; then
+        worker_id="$WORK_WORKER_ID"
+    else
+        echo "Error: --stage requires an issue number or must be run from within a worker session"
+        echo "Usage: work --stage <stage> [issue]"
+        exit 1
+    fi
+
+    if db_update_stage "$worker_id" "$stage"; then
+        echo "Stage updated to: $stage"
     fi
 }
 
@@ -1065,31 +1013,6 @@ Then output a summary including:
 - **Files changed**: List of key files modified
 - **Key decisions made**: Any architectural or implementation choices
 - **Follow-up issues created**: Links to any issues created for future work
-
-## Stage Tracking (IMPORTANT)
-Report your current stage as you progress through the workflow. This helps monitor parallel workers and identify bottlenecks.
-
-**Update your stage when transitioning between phases:**
-\`\`\`bash
-work --stage exploring       # Reading issue, understanding codebase
-work --stage planning        # Designing approach, creating todo list
-work --stage implementing    # Writing code
-work --stage testing         # Running local tests
-work --stage pr_creating     # Creating PR, writing description
-work --stage ci_waiting --pr <NUMBER>  # PR created, waiting for CI
-work --stage review_waiting  # CI passed, waiting for review
-work --stage review_responding  # Addressing review feedback
-work --stage merge_conflicts # Resolving merge conflicts
-work --stage done            # PR merged or issue closed
-work --stage blocked         # Waiting on external dependency
-\`\`\`
-
-**Stage transitions map to workflow phases:**
-- Phase 1 (Implementation): exploring → planning → implementing → testing
-- Phase 2 (Pull Request): pr_creating
-- Phase 3 (CI & Review): ci_waiting → review_waiting → review_responding (may cycle)
-- Phase 4 (Merge): done
-- Any time: blocked (with explanation), merge_conflicts
 
 ## Guidelines
 - Be thorough but avoid over-engineering


### PR DESCRIPTION
## Summary
- Add `--stage` command for workers to report their current stage in the workflow lifecycle
- Provides better visibility into where workers are vs showing "running" for everything
- Tracks stage changes in events table for monitoring

## Stages
| Stage | Description |
|-------|-------------|
| `exploring` | Reading issue, understanding codebase |
| `planning` | Designing approach, creating todo list |
| `implementing` | Writing code |
| `testing` | Running local tests |
| `pr_creating` | Creating PR, writing description |
| `ci_waiting` | PR created, waiting for CI to pass |
| `review_waiting` | CI passed, waiting for review |
| `review_responding` | Addressing review feedback |
| `merge_conflicts` | Resolving merge conflicts |
| `done` | PR merged or issue closed |
| `blocked` | Waiting on external dependency |

## Test plan
- [x] Test `work --stage` without arguments shows help
- [x] Test `work --stage invalid` shows error with valid stages
- [x] Test `work --stage implementing` updates stage when WORK_WORKER_ID is set
- [x] Test `work --status` shows stage column in output
- [x] Test `work --events` shows stage_change events
- [x] Test database migration works for existing databases

Closes #10