### PR TITLE
Add auto-detection hooks for work stage transitions

### DIFF
--- a/genai/hooks/README.md
+++ b/genai/hooks/README.md
@@ -1,0 +1,85 @@
+# Work Stage Detection Hooks
+
+This directory contains Claude Code hooks for auto-detecting work stage transitions.
+
+## Overview
+
+The `work-stage-detector.sh` hook automatically detects workflow events from Bash commands and updates the worker's status in the SQLite database.
+
+### Supported Stage Transitions
+
+| Event | Resulting Stage | Phase |
+|-------|-----------------|-------|
+| `gh pr create` | `ci_waiting` | `ci_review` |
+| CI passes (`gh pr checks`) | `review_waiting` | `review` |
+| `gh pr merge` | `merged` | `follow_up` |
+| Merge/rebase conflicts | `merge_conflicts` | `blocked` |
+| Conflict resolved | `running` | `implementation` |
+
+## Installation
+
+### Automatic Installation
+
+Run the installation script:
+
+```bash
+./genai/hooks/install-hooks.sh
+```
+
+### Manual Installation
+
+1. Copy or symlink the hook to your Claude hooks directory:
+
+```bash
+mkdir -p ~/.claude/hooks
+ln -sf "$(pwd)/genai/hooks/work-stage-detector.sh" ~/.claude/hooks/
+```
+
+2. Add the hook configuration to your Claude settings (`~/.claude/settings.json`):
+
+```json
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/work-stage-detector.sh",
+            "timeout": 5000
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+## Requirements
+
+- `jq` must be installed for JSON parsing
+- `sqlite3` must be installed for database updates
+- Environment variables `WORK_WORKER_ID` and `WORK_DB_PATH` must be set (automatically set by the `work` script)
+
+## How It Works
+
+1. The hook runs after every Bash tool call in Claude Code
+2. It parses the command and output from the hook input (JSON via stdin)
+3. It detects workflow events (PR creation, CI checks, merges, conflicts)
+4. It updates the worker's status/phase in the SQLite database
+5. It logs events to the `events` table for tracking
+
+## Debugging
+
+To see hook activity, check the events table:
+
+```bash
+sqlite3 ~/.worktrees/work-sessions.db "SELECT * FROM events ORDER BY created_at DESC LIMIT 20;"
+```
+
+Or use the work script:
+
+```bash
+work --events
+```

--- a/genai/hooks/install-hooks.sh
+++ b/genai/hooks/install-hooks.sh
@@ -1,0 +1,152 @@
+#!/bin/bash
+# install-hooks.sh - Install work stage detection hooks for Claude Code
+#
+# This script:
+# 1. Creates the ~/.claude/hooks directory
+# 2. Symlinks the work-stage-detector.sh hook
+# 3. Updates ~/.claude/settings.json with hook configuration
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CLAUDE_DIR="${HOME}/.claude"
+HOOKS_DIR="${CLAUDE_DIR}/hooks"
+SETTINGS_FILE="${CLAUDE_DIR}/settings.json"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+info() { echo -e "${GREEN}[INFO]${NC} $*"; }
+warn() { echo -e "${YELLOW}[WARN]${NC} $*"; }
+error() { echo -e "${RED}[ERROR]${NC} $*" >&2; }
+
+# Check dependencies
+check_dependencies() {
+    local missing=()
+
+    if ! command -v jq &>/dev/null; then
+        missing+=("jq")
+    fi
+
+    if ! command -v sqlite3 &>/dev/null; then
+        missing+=("sqlite3")
+    fi
+
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        error "Missing required dependencies: ${missing[*]}"
+        echo "Please install them and try again."
+        exit 1
+    fi
+}
+
+# Create directories
+setup_directories() {
+    info "Creating Claude hooks directory..."
+    mkdir -p "$HOOKS_DIR"
+}
+
+# Install hook script
+install_hook() {
+    local hook_source="${SCRIPT_DIR}/work-stage-detector.sh"
+    local hook_dest="${HOOKS_DIR}/work-stage-detector.sh"
+
+    if [[ ! -f "$hook_source" ]]; then
+        error "Hook script not found: $hook_source"
+        exit 1
+    fi
+
+    info "Installing work-stage-detector.sh..."
+
+    # Remove existing symlink or file
+    if [[ -L "$hook_dest" ]] || [[ -f "$hook_dest" ]]; then
+        rm "$hook_dest"
+    fi
+
+    # Create symlink
+    ln -sf "$hook_source" "$hook_dest"
+    chmod +x "$hook_dest"
+
+    info "Hook installed: $hook_dest -> $hook_source"
+}
+
+# Update settings.json with hook configuration
+update_settings() {
+    info "Updating Claude settings..."
+
+    # Hook configuration to add
+    local hook_config='{
+        "matcher": "Bash",
+        "hooks": [
+            {
+                "type": "command",
+                "command": "~/.claude/hooks/work-stage-detector.sh",
+                "timeout": 5000
+            }
+        ]
+    }'
+
+    # Create settings file if it doesn't exist
+    if [[ ! -f "$SETTINGS_FILE" ]]; then
+        echo '{}' > "$SETTINGS_FILE"
+    fi
+
+    # Read current settings
+    local current_settings
+    current_settings=$(cat "$SETTINGS_FILE")
+
+    # Check if hooks.PostToolUse already exists
+    if echo "$current_settings" | jq -e '.hooks.PostToolUse' &>/dev/null; then
+        # Check if our hook is already configured
+        if echo "$current_settings" | jq -e '.hooks.PostToolUse[] | select(.hooks[].command | contains("work-stage-detector"))' &>/dev/null; then
+            info "Hook already configured in settings.json"
+            return 0
+        fi
+
+        # Add our hook to existing PostToolUse array
+        info "Adding hook to existing PostToolUse configuration..."
+        local new_settings
+        new_settings=$(echo "$current_settings" | jq --argjson hook "$hook_config" '.hooks.PostToolUse += [$hook]')
+        echo "$new_settings" > "$SETTINGS_FILE"
+    else
+        # Create hooks.PostToolUse array
+        info "Creating PostToolUse hook configuration..."
+        local new_settings
+        new_settings=$(echo "$current_settings" | jq --argjson hook "$hook_config" '.hooks.PostToolUse = [$hook]')
+        echo "$new_settings" > "$SETTINGS_FILE"
+    fi
+
+    info "Settings updated: $SETTINGS_FILE"
+}
+
+# Main
+main() {
+    echo "=========================================="
+    echo "Work Stage Detection Hooks Installer"
+    echo "=========================================="
+    echo ""
+
+    check_dependencies
+    setup_directories
+    install_hook
+    update_settings
+
+    echo ""
+    echo "=========================================="
+    info "Installation complete!"
+    echo ""
+    echo "The hook will automatically detect:"
+    echo "  - PR creation (gh pr create)"
+    echo "  - CI status changes (gh pr checks)"
+    echo "  - PR merges (gh pr merge)"
+    echo "  - Merge conflicts (git rebase/merge)"
+    echo ""
+    echo "To uninstall, run:"
+    echo "  rm ~/.claude/hooks/work-stage-detector.sh"
+    echo "  # Then remove the hook entry from ~/.claude/settings.json"
+    echo "=========================================="
+}
+
+main "$@"

--- a/genai/hooks/work-stage-detector.sh
+++ b/genai/hooks/work-stage-detector.sh
@@ -1,0 +1,150 @@
+#!/bin/bash
+# work-stage-detector.sh - Claude Code hook for auto-detecting work stage transitions
+#
+# This PostToolUse hook detects workflow events from Bash commands and updates
+# the worker's stage in the SQLite database. It supports:
+#
+#   Event                    | Resulting Stage
+#   -------------------------|----------------
+#   gh pr create             | ci_waiting
+#   CI passes (gh pr checks) | review_waiting
+#   gh pr merge              | done
+#   Merge/rebase conflicts   | merge_conflicts
+
+set -euo pipefail
+
+# Read hook input from stdin
+HOOK_INPUT=$(cat)
+
+# Check if we have required environment variables
+if [[ -z "${WORK_WORKER_ID:-}" ]] || [[ -z "${WORK_DB_PATH:-}" ]]; then
+    exit 0
+fi
+
+# Verify database exists
+if [[ ! -f "$WORK_DB_PATH" ]]; then
+    exit 0
+fi
+
+# Extract tool info using jq
+TOOL_NAME=$(echo "$HOOK_INPUT" | jq -r '.tool_name // empty')
+
+# Only process Bash tool calls
+if [[ "$TOOL_NAME" != "Bash" ]]; then
+    exit 0
+fi
+
+COMMAND=$(echo "$HOOK_INPUT" | jq -r '.tool_input.command // empty')
+STDOUT=$(echo "$HOOK_INPUT" | jq -r '.tool_response.stdout // empty' 2>/dev/null || echo "")
+STDERR=$(echo "$HOOK_INPUT" | jq -r '.tool_response.stderr // empty' 2>/dev/null || echo "")
+EXIT_CODE=$(echo "$HOOK_INPUT" | jq -r '.tool_response.exitCode // .tool_response.exit_code // "0"' 2>/dev/null || echo "0")
+RESPONSE="${STDOUT}${STDERR}"
+
+# Helper function to update worker status and log event
+update_worker() {
+    local status="$1"
+    local phase="$2"
+    local event_type="$3"
+    local message="$4"
+
+    sqlite3 "$WORK_DB_PATH" <<SQL
+UPDATE workers
+SET status='$status', phase='$phase', updated_at=CURRENT_TIMESTAMP
+WHERE id=$WORK_WORKER_ID;
+
+INSERT INTO events (worker_id, event_type, message)
+VALUES ($WORK_WORKER_ID, '$event_type', '$message');
+SQL
+}
+
+# Helper function to log event only (no status change)
+log_event() {
+    local event_type="$1"
+    local message="$2"
+
+    sqlite3 "$WORK_DB_PATH" "INSERT INTO events (worker_id, event_type, message) VALUES ($WORK_WORKER_ID, '$event_type', '$message');"
+}
+
+# Helper function to update PR info
+update_pr_info() {
+    local pr_number="$1"
+    local pr_url="$2"
+
+    sqlite3 "$WORK_DB_PATH" <<SQL
+UPDATE workers
+SET pr_number=$pr_number, pr_url='$pr_url', status='ci_waiting', phase='ci_review', updated_at=CURRENT_TIMESTAMP
+WHERE id=$WORK_WORKER_ID;
+
+INSERT INTO events (worker_id, event_type, message)
+VALUES ($WORK_WORKER_ID, 'pr_created', 'PR #$pr_number created');
+SQL
+}
+
+# Detect PR creation: gh pr create or ghe pr create
+if [[ "$COMMAND" =~ gh[e]?[[:space:]]+pr[[:space:]]+create ]] && [[ "$EXIT_CODE" == "0" ]]; then
+    # Extract PR URL from output (format: https://github.com/owner/repo/pull/123)
+    PR_URL=$(echo "$STDOUT" | grep -oE 'https://[^[:space:]]+/pull/[0-9]+' | head -1 || true)
+
+    if [[ -n "$PR_URL" ]]; then
+        # Extract PR number from URL
+        PR_NUMBER=$(echo "$PR_URL" | grep -oE '[0-9]+$')
+        if [[ -n "$PR_NUMBER" ]]; then
+            update_pr_info "$PR_NUMBER" "$PR_URL"
+        fi
+    fi
+    exit 0
+fi
+
+# Detect CI check results: gh pr checks
+if [[ "$COMMAND" =~ gh[e]?[[:space:]]+pr[[:space:]]+checks ]]; then
+    # Check if watching (--watch flag)
+    if [[ "$COMMAND" =~ --watch ]]; then
+        # For --watch, we need to check the final status
+        if echo "$STDOUT" | grep -qiE '(fail|error)'; then
+            log_event "ci_failure" "CI checks failed"
+        elif echo "$STDOUT" | grep -qiE '(pass|success|✓)' && ! echo "$STDOUT" | grep -qiE '(pending|running|queued)'; then
+            # All checks passed - transition to review_waiting
+            update_worker "review_waiting" "review" "ci_passed" "All CI checks passed"
+        fi
+    else
+        # Non-watch mode: just log the check
+        if echo "$STDOUT" | grep -qiE '(fail|error)'; then
+            log_event "ci_check" "CI checks show failures"
+        elif echo "$STDOUT" | grep -qiE '(pass|success|✓)'; then
+            if ! echo "$STDOUT" | grep -qiE '(pending|running|queued)'; then
+                update_worker "review_waiting" "review" "ci_passed" "All CI checks passed"
+            fi
+        fi
+    fi
+    exit 0
+fi
+
+# Detect PR merge: gh pr merge
+if [[ "$COMMAND" =~ gh[e]?[[:space:]]+pr[[:space:]]+merge ]] && [[ "$EXIT_CODE" == "0" ]]; then
+    # Check if merge was successful from output
+    if echo "$RESPONSE" | grep -qiE '(merged|successfully)'; then
+        update_worker "merged" "follow_up" "pr_merged" "PR merged successfully"
+    fi
+    exit 0
+fi
+
+# Detect resolved conflicts: git rebase --continue or git merge --continue
+# NOTE: This must come BEFORE the conflict detection check since both match git rebase/merge
+if [[ "$COMMAND" =~ git[[:space:]]+(rebase|merge)[[:space:]]+--continue ]] && [[ "$EXIT_CODE" == "0" ]]; then
+    # Get current status to see if we were in merge_conflicts
+    CURRENT_STATUS=$(sqlite3 "$WORK_DB_PATH" "SELECT status FROM workers WHERE id=$WORK_WORKER_ID;")
+    if [[ "$CURRENT_STATUS" == "merge_conflicts" ]]; then
+        update_worker "running" "implementation" "conflict_resolved" "Merge conflicts resolved"
+    fi
+    exit 0
+fi
+
+# Detect merge conflicts from git rebase or git merge
+if [[ "$COMMAND" =~ git[[:space:]]+(rebase|merge|pull) ]]; then
+    if echo "$RESPONSE" | grep -qiE '(CONFLICT|conflict|Automatic merge failed)'; then
+        update_worker "merge_conflicts" "blocked" "conflict_detected" "Merge conflict detected"
+    fi
+    exit 0
+fi
+
+exit 0

--- a/genai/skills/work/SKILL.md
+++ b/genai/skills/work/SKILL.md
@@ -77,6 +77,38 @@ Message types:
 5. Starts Claude Code with a structured prompt for end-to-end completion
 6. Tracks worker status (starting, running, pr_open, ci_waiting, done, failed)
 
+## Auto-Detection Hooks
+
+When installed, Claude Code hooks automatically detect workflow events and update worker status:
+
+| Event | Resulting Status | Phase |
+|-------|-----------------|-------|
+| `gh pr create` | `ci_waiting` | `ci_review` |
+| CI passes (`gh pr checks`) | `review_waiting` | `review` |
+| `gh pr merge` | `merged` | `follow_up` |
+| Merge/rebase conflicts | `merge_conflicts` | `blocked` |
+| Conflict resolved | `running` | `implementation` |
+
+### Installing Hooks
+
+```bash
+# Run the installer from your dotfiles repo
+./genai/hooks/install-hooks.sh
+```
+
+This installs a PostToolUse hook that monitors Bash commands and automatically updates the worker database.
+
+### How It Works
+
+The hook script (`~/.claude/hooks/work-stage-detector.sh`):
+1. Runs after every Bash tool call
+2. Parses the command and output from the hook input
+3. Detects workflow events (PR creation, CI checks, merges, conflicts)
+4. Updates the worker's status/phase in the SQLite database
+5. Logs events for tracking via `work --events`
+
+This eliminates manual stage reporting, ensuring accurate workflow progression tracking.
+
 ## Database
 
 Worker state is stored in `~/.worktrees/work-sessions.db` with four tables:


### PR DESCRIPTION
## Summary

- Adds Claude Code hooks that automatically detect workflow events and update worker status
- Eliminates manual stage reporting by detecting commands like `gh pr create`, `gh pr merge`, etc.
- Provides an installation script for easy setup

## Stage Transitions Detected

| Event | Resulting Status | Phase |
|-------|-----------------|-------|
| `gh pr create` | `ci_waiting` | `ci_review` |
| CI passes (`gh pr checks`) | `review_waiting` | `review` |
| `gh pr merge` | `merged` | `follow_up` |
| Merge/rebase conflicts | `merge_conflicts` | `blocked` |
| Conflict resolved | `running` | `implementation` |

## Files Changed

- `genai/hooks/work-stage-detector.sh` - PostToolUse hook that parses Bash commands
- `genai/hooks/install-hooks.sh` - Installation script that symlinks the hook and updates settings.json
- `genai/hooks/README.md` - Documentation for the hooks
- `genai/skills/work/SKILL.md` - Updated with hook documentation

## Installation

```bash
./genai/hooks/install-hooks.sh
```

## Test plan

- [x] Tested PR creation detection with mock input
- [x] Tested CI pass detection with mock input
- [x] Tested PR merge detection with mock input
- [x] Tested conflict detection with mock input
- [x] Tested conflict resolution detection with mock input
- [x] Verified syntax with `bash -n`

Closes #12